### PR TITLE
added `getDefaultIndentation` to `Layout`

### DIFF
--- a/io7m-jpplib-core/src/main/java/de/uka/ilkd/pp/Layouter.java
+++ b/io7m-jpplib-core/src/main/java/de/uka/ilkd/pp/Layouter.java
@@ -413,6 +413,17 @@ public class Layouter<Exc extends Exception> {
 				indentation);
 	}
 
+	// PROPERTY GETTERS ------------------------------------
+
+	/**
+	 * Gets default indentation for this block
+	 *
+	 * @return default indentation
+	 */
+	public int getDefaultIndentation() {
+		return defaultInd;
+	}
+
 	// PRIMITIVE STREAM OPERATIONS ------------------------------------
 
 	/**


### PR DESCRIPTION
`Layouter` needs a way to get current default indentation, otherwise it's impossible to properly place closing brace when printing blocks like this:

```
someStructure {
  entry1
  entry2
}
```

current approach is:

```
prettyPrint(DataLayouter<E> l) throws E {
  l.beginCInd(); // start block with default indent (which we don't know)
  l.print("someStructure {");
  l.brk().print("entry1");
  l.brk().print("entry2");
  // now we want closing brace to be un-indented if it's on a new line
  // but we don't know current level. The only way is to guess:
  l.brk(1, -2).end().print('}');
}
```

with the patch last line should become `l.brk(1, -l.getDefaultIndentation()).end().print('}');`
